### PR TITLE
Downgrade PHP to 7.1 to fix session errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7.1-apache
 MAINTAINER Kristoph Junge <kristoph.junge@gmail.com>
 
 # Utilities


### PR DESCRIPTION
The current "php:7-apache" tag installs PHP 7.2 which errors with:

```
Warning: session_cache_limiter(): Cannot change cache limiter when session is active in /var/www/simplesamlphp/lib/SimpleSAML/SessionHandlerPHP.php on line 117
```

on most screens.

Downgrading PHP back to 7.1 fixes that.