### PR TITLE
Dynamic test config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN a2dissite 000-default.conf default-ssl.conf
 RUN a2ensite simplesamlphp.conf
 
 # Make config writeable by apache so that our testapi can update config
-RUN chown -R www-data.www-data /var/www/simplesamlphp/metadata
+RUN chown -R www-data.www-data /var/www/simplesamlphp/metadata /var/www/simplesamlphp/config
 
 # Copy in scripts that provide an API to adjust SP remotes dynamically in tests.
 COPY config/testapi/* /var/www/simplesamlphp/www/testapi/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN a2enmod ssl
 RUN a2dissite 000-default.conf default-ssl.conf
 RUN a2ensite simplesamlphp.conf
 
+# Make config writeable by apache so that our testapi can update config
+RUN chown -R www-data.www-data /var/www/simplesamlphp/metadata
+
+# Copy in scripts that provide an API to adjust SP remotes dynamically in tests.
+COPY config/testapi/* /var/www/simplesamlphp/www/testapi/
+
 # Set work dir
 WORKDIR /var/www/simplesamlphp
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ Start the development IdP with the command above (usage) and initiate the login 
 Click under `Authentication` > `Test configured authentication sources` > `test-sp` and login with one of the test credentials.
 
 
+## Dynamic config during tests
+
+In some test environments you may not know what path or even domain the SP is going to be on until after the IdP container has already started, in that case it can be useful to update config dynamically in the already running container.
+
+No verification is done on any of these calls, if you break config with a bad call, you're on your own!
+
+### Service Providers
+
+It's possible add SPs dynamically by POSTing to the `simplesaml/testapi/add-sp-remote.php` script.
+
+For documentation on how SPs can be configured, see https://simplesamlphp.org/docs/stable/simplesamlphp-reference-sp-remote .
+
+The script requires two parameters:
+
+ * `name` - the name of the remote, ideally it should be unique (e.g use [uniqid()](http://php.net/uniqid) as part of the name) as duplicate names will simply overwrite each other
+ * `data` - configuration for this SP encoded as JSON
+
+Example:
+
+```
+curl -d "name=foo" -d 'data={"AssertionConsumerService": "http://.../", "SingleLogoutService": "http://.../"}' -sv http://$samlContainer/simplesaml/testapi/add-sp-remote.php
+```
+
 ## License
 
 This project is licensed under the MIT license by Kristoph Junge.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ Example:
 curl -d "name=foo" -d 'data={"AssertionConsumerService": "http://.../", "SingleLogoutService": "http://.../"}' -sv http://$samlContainer/simplesaml/testapi/add-sp-remote.php
 ```
 
+### Users
+
+The `simplesaml/testapi/add-user.php` script can be used to add a new user to the `example-userpass` authentication source.
+
+The script requires two parameters:
+
+ * `user` - the username and password formatted as `user:pass`
+ * `metadata` - the metadata for the user encoded as JSON
+
+Example:
+
+```
+curl -d "user=foo:bar" -d 'metadata={"email": "foo@example.com"}' -sv http://$samlContainer/simplesaml/testapi/add-user.php
+```
+
 ## License
 
 This project is licensed under the MIT license by Kristoph Junge.

--- a/config/testapi/add-sp-remote.php
+++ b/config/testapi/add-sp-remote.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Add a new SP remote
+ *
+ * Call this from test set up code to enable whatever dynamic URL the code under
+ * test is running on to be used via the SimpleSAML IdP.
+ */
+// name of the SP remote (ideally unique)
+$name = $_POST['name'];
+// configuration data for the SP remote
+$data = json_decode($_POST['data'], true);
+// where our config is
+$file = '/var/www/simplesamlphp/metadata/saml20-sp-remote.php';
+// lets just append to the $metadata array
+$contents = file_get_contents($file);
+$contents .= "\$metadata[".var_export($name, true)."] = ".var_export($data, true).";\n";
+file_put_contents($file, $contents);

--- a/config/testapi/add-user.php
+++ b/config/testapi/add-user.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Add a new test user to the example-userpass authentication source
+ *
+ * Call this from test set up code to add a new user to test with
+ */
+// user - formatted as "user:pass"
+$user = $_POST['user'];
+// user metadata
+$metadata = json_decode($_POST['metadata'], true);
+// where our config is
+$file = '/var/www/simplesamlphp/config/authsources.php';
+
+// load the current config
+require($file);
+// append our new user
+$config['example-userpass'][$user] = $metadata;
+// save the new config
+$contents = "<?php \$config = ".var_export($config, true).";\n";
+file_put_contents($file, $contents);


### PR DESCRIPTION
I'd like to be able to add SP remotes and users after the container has already started without having to share the file system via volume mounts.

More description on #5.