### PR TITLE
Enable using env vars to set users and SP metadata

### DIFF
--- a/config/simplesamlphp/authsources.php
+++ b/config/simplesamlphp/authsources.php
@@ -1,13 +1,6 @@
 <?php
 
-$config = array(
-
-    'admin' => array(
-        'core:AdminPassword',
-    ),
-
-    'example-userpass' => array(
-        'exampleauth:UserPass',
+$users = array(
         'user1:user1pass' => array(
             'uid' => array('1'),
             'eduPersonAffiliation' => array('group1'),
@@ -18,6 +11,18 @@ $config = array(
             'eduPersonAffiliation' => array('group2'),
             'email' => 'user2@example.com',
         ),
+    );
+if (getenv('SIMPLESAMLPHP_USERS') != '') {
+    $decoded = json_decode(getenv('SIMPLESAMLPHP_USERS'), TRUE);
+    $users = $decoded? $decoded : $users;
+}
+
+$config = array(
+
+    'admin' => array(
+        'core:AdminPassword',
     ),
+
+    'example-userpass' => array('exampleauth:UserPass') + $users
 
 );

--- a/config/simplesamlphp/saml20-sp-remote.php
+++ b/config/simplesamlphp/saml20-sp-remote.php
@@ -5,7 +5,18 @@
  * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-sp-remote
  */
 
-$metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array(
-    'AssertionConsumerService' => getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE'),
-    'SingleLogoutService' => getenv('SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE'),
+if (getenv('SIMPLESAMLPHP_SP_METADATA') != '') {
+    $sp_metadata = json_decode(getenv('SIMPLESAMLPHP_SP_METADATA'), TRUE);
+    foreach ($sp_metadata as $entity_id => $values) {
+        $metadata[$entity_id] = $values;
+    }
+} else {
+    $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array(
+        'AssertionConsumerService' => getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE'),
+        'SingleLogoutService' => getenv('SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE'),
 );
+}
+
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,46 @@ services:
   testsamlidp_idp:
     build: .
     environment:
-      SIMPLESAMLPHP_SP_ENTITY_ID: http://app.example.com
-      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/test-sp
-      SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: http://localhost/simplesaml/module.php/saml/sp/saml2-logout.php/test-sp
+      # SIMPLESAMLPHP_SP_ENTITY_ID: http://app.example.com
+      # SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/test-sp
+      # SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: http://localhost/simplesaml/module.php/saml/sp/saml2-logout.php/test-sp
       SIMPLESAMLPHP_ADMIN_PASSWORD: test
       SIMPLESAMLPHP_SECRET_SALT: salt
+      SIMPLESAMLPHP_SP_METADATA: |
+        {
+            "http://app.example.com": {
+                "AssertionConsumerService": "http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/test-sp",
+                "SingleLogoutService": "http://localhost/simplesaml/module.php/saml/sp/saml2-logout.php/test-sp" 
+            },
+            "passport-saml": {
+                "OrganizationName": "PassportJS SAML example",
+                "OrganizationURL": "https://github.com/gbraad/passport-saml-example",
+                "AssertionConsumerService": "http://localhost:3000/login/callback",
+                "SingleLogoutService": "http://localhost:3000/simplesaml/logout" 
+            },
+            "http://localhost:8888": {
+                "AssertionConsumerService": "http://localhost:8888/logon"
+            }
+        }
+      SIMPLESAMLPHP_USERS: |
+        {
+            "user1:user1pass": {
+                "email": "user1@env-var.com",
+                "UID": "us11111",
+                "Country code": "US",
+                "name": "Joe User",
+                "Telephone number": "555-11-11-11",
+                "Another Attribute": "one"
+            },
+            "user2:user2pass": {
+                "email": "user2@env-var.com",
+                "UID": "us22222",
+                "Country code": "44",
+                "name": "Jack User",
+                "Telephone number": "555-22-22-22",
+                "Another Attribute": "two"
+            }
+        }
     ports:
     - "8080:8080"
     - "8443:8443"
-    #volumes:
-    #- /users.php:/var/www/simplesamlphp/config/simplesamlphp/authsources.php


### PR DESCRIPTION
The use of env vars makes simpler to run the original image without modification