### PR TITLE
add SIMPLESAMLPHP_BASE_URL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Start the development IdP with the command above (usage) and initiate the login 
 
 Click under `Authentication` > `Test configured authentication sources` > `test-sp` and login with one of the test credentials.
 
+### Behind a reverse proxy
+
+If you need to deal with HTTPS or a different port behing a reverse proxy, override the default SimpleSamlPhp `baseurlpath` by adding the following env:
+```
+SIMPLESAMLPHP_BASE_URL=https://your.canonical.host.name/simplesaml/
+``` 
 
 ## Contributing
 

--- a/config/simplesamlphp/config.php
+++ b/config/simplesamlphp/config.php
@@ -21,7 +21,7 @@ $config = array(
      * external url, no matter where you come from (direct access or via the
      * reverse proxy).
      */
-    'baseurlpath' => 'simplesaml/',
+    'baseurlpath' => !empty(getenv('SIMPLESAMLPHP_BASE_URL')) ? getenv('SIMPLESAMLPHP_BASE_URL') : 'simplesaml/',
     'certdir' => 'cert/',
     'loggingdir' => 'log/',
     'datadir' => 'data/',


### PR DESCRIPTION
Allow to override the `baseurlpath` config.