### PR TITLE
Add environment variables to support persistent ids

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -r /var/lib/apt/lists/*
 
 # SimpleSAMLphp
-ARG SIMPLESAMLPHP_VERSION=1.15.2
+ARG SIMPLESAMLPHP_VERSION=1.18.8
 RUN curl -s -L -o /tmp/simplesamlphp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SIMPLESAMLPHP_VERSION/simplesamlphp-$SIMPLESAMLPHP_VERSION.tar.gz && \
     tar xzf /tmp/simplesamlphp.tar.gz -C /tmp && \
     rm -f /tmp/simplesamlphp.tar.gz  && \
@@ -16,6 +16,7 @@ RUN curl -s -L -o /tmp/simplesamlphp.tar.gz https://github.com/simplesamlphp/sim
 COPY config/simplesamlphp/config.php /var/www/simplesamlphp/config
 COPY config/simplesamlphp/authsources.php /var/www/simplesamlphp/config
 COPY config/simplesamlphp/saml20-sp-remote.php /var/www/simplesamlphp/metadata
+COPY config/simplesamlphp/saml20-idp-hosted.php /var/www/simplesamlphp/metadata
 COPY config/simplesamlphp/server.crt /var/www/simplesamlphp/cert/
 COPY config/simplesamlphp/server.pem /var/www/simplesamlphp/cert/
 

--- a/config/simplesamlphp/authsources.php
+++ b/config/simplesamlphp/authsources.php
@@ -15,5 +15,19 @@ $config = array(
           'uid' => array('1'),
           'eduPersonAffiliation' => array('group1'),
           'email' => 'user1@example.com',
-  	]
+  	],
+
+    'example-userpass' => array(
+        'exampleauth:UserPass',
+        'user1:user1pass' => array(
+            'uid' => array('1'),
+            'eduPersonAffiliation' => array('group1'),
+            'email' => 'user1@example.com',
+        ),
+        'user2:user2pass' => array(
+            'uid' => array('2'),
+            'eduPersonAffiliation' => array('group2'),
+            'email' => 'user2@example.com',
+        ),
+    )
 );

--- a/config/simplesamlphp/authsources.php
+++ b/config/simplesamlphp/authsources.php
@@ -17,6 +17,8 @@ $config = array(
           'email' => 'user1@example.com',
   	],
 
+    /*In this mode there are 3 users user1, user2, user3 which belong to
+    group1, group2 and group1 and group2 respectively*/
     'example-userpass' => array(
         'exampleauth:UserPass',
         'user1:user1pass' => array(
@@ -28,6 +30,11 @@ $config = array(
             'uid' => array('2'),
             'eduPersonAffiliation' => array('group2'),
             'email' => 'user2@example.com',
+        ),
+        'user3:user3pass' => array(
+            'uid' => array('3'),
+            'eduPersonAffiliation' => array('group1','group2'),
+            'email' => 'user3@example.com',
         ),
     )
 );

--- a/config/simplesamlphp/authsources.php
+++ b/config/simplesamlphp/authsources.php
@@ -6,18 +6,14 @@ $config = array(
         'core:AdminPassword',
     ),
 
-    'example-userpass' => array(
-        'exampleauth:UserPass',
-        'user1:user1pass' => array(
-            'uid' => array('1'),
-            'eduPersonAffiliation' => array('group1'),
-            'email' => 'user1@example.com',
-        ),
-        'user2:user2pass' => array(
-            'uid' => array('2'),
-            'eduPersonAffiliation' => array('group2'),
-            'email' => 'user2@example.com',
-        ),
-    ),
+    'example-static' => [
+  	/* This maps to modules/exampleauth/lib/Auth/Source/Static.php */
+ 	 'exampleauth:StaticSource',
 
+	  /* The following is configuration which is passed on to
+	   * the exampleauth:StaticSource authentication source. */
+          'uid' => array('1'),
+          'eduPersonAffiliation' => array('group1'),
+          'email' => 'user1@example.com',
+  	]
 );

--- a/config/simplesamlphp/saml20-idp-hosted.php
+++ b/config/simplesamlphp/saml20-idp-hosted.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * SAML 2.0 IdP configuration for SimpleSAMLphp.
+ *
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
+ */
+
+$metadata['__DYNAMIC:1__'] = array(
+	/*
+	 * The hostname of the server (VHOST) that will use this SAML entity.
+	 *
+	 * Can be '__DEFAULT__', to use this entry by default.
+	 */
+	'host' => '__DEFAULT__',
+
+	// X.509 key and certificate. Relative to the cert directory.
+	'privatekey' => 'server.pem',
+	'certificate' => 'server.crt',
+
+	/*
+	 * Authentication source to use. Must be one that is configured in
+	 * 'config/authsources.php'.
+	 */
+	'auth' => 'example-static',
+
+	/*
+	 * WARNING: SHA-1 is disallowed starting January the 1st, 2014.
+	 *
+	 * Uncomment the following option to start using SHA-256 for your signatures.
+	 * Currently, SimpleSAMLphp defaults to SHA-1, which has been deprecated since
+	 * 2011, and will be disallowed by NIST as of 2014. Please refer to the following
+	 * document for more information:
+	 * 
+	 * http://csrc.nist.gov/publications/nistpubs/800-131A/sp800-131A.pdf
+	 *
+	 * If you are uncertain about service providers supporting SHA-256 or other
+	 * algorithms of the SHA-2 family, you can configure it individually in the
+	 * SP-remote metadata set for those that support it. Once you are certain that
+	 * all your configured SPs support SHA-2, you can safely remove the configuration
+	 * options in the SP-remote metadata set and uncomment the following option.
+	 *
+	 * Please refer to the IdP hosted reference for more information.
+	 */
+	//'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+
+	/* Uncomment the following to use the uri NameFormat on attributes. */
+	/*
+	'attributes.NameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+	'authproc' => array(
+		// Convert LDAP names to oids.
+		100 => array('class' => 'core:AttributeMap', 'name2oid'),
+	),
+	*/
+
+	/*
+	 * Uncomment the following to specify the registration information in the
+	 * exported metadata. Refer to:
+     * http://docs.oasis-open.org/security/saml/Post2.0/saml-metadata-rpi/v1.0/cs01/saml-metadata-rpi-v1.0-cs01.html
+	 * for more information.
+	 */
+	/*
+	'RegistrationInfo' => array(
+		'authority' => 'urn:mace:example.org',
+		'instant' => '2008-01-17T11:28:03Z',
+		'policies' => array(
+			'en' => 'http://example.org/policy',
+			'es' => 'http://example.org/politica',
+		),
+	),
+	*/
+);
+

--- a/config/simplesamlphp/saml20-idp-hosted.php
+++ b/config/simplesamlphp/saml20-idp-hosted.php
@@ -21,7 +21,7 @@ $metadata['__DYNAMIC:1__'] = array(
 	 * Authentication source to use. Must be one that is configured in
 	 * 'config/authsources.php'.
 	 */
-	'auth' => 'example-static',
+	'auth' => getenv('SIMPLESAMLPHP_IDP_AUTH'),
 
 	/*
 	 * WARNING: SHA-1 is disallowed starting January the 1st, 2014.

--- a/config/simplesamlphp/saml20-sp-remote.php
+++ b/config/simplesamlphp/saml20-sp-remote.php
@@ -17,3 +17,7 @@ if (null != getenv('SIMPLESAMLPHP_SP_NAME_ID_FORMAT')) {
 if (null != getenv('SIMPLESAMLPHP_SP_NAME_ID_ATTRIBUTE')) {
     $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array_merge($metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')], array('simplesaml.nameidattribute' => getenv('SIMPLESAMLPHP_SP_NAME_ID_ATTRIBUTE')));
 }
+
+if (null != getenv('SIMPLESAMLPHP_SP_SIGN_ASSERTION')) {
+    $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array_merge($metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')], array('saml20.sign.assertion' => ('true' == getenv('SIMPLESAMLPHP_SP_SIGN_ASSERTION'))));
+}

--- a/config/simplesamlphp/saml20-sp-remote.php
+++ b/config/simplesamlphp/saml20-sp-remote.php
@@ -9,3 +9,11 @@ $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array(
     'AssertionConsumerService' => getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE'),
     'SingleLogoutService' => getenv('SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE'),
 );
+
+if (null != getenv('SIMPLESAMLPHP_SP_NAME_ID_FORMAT')) {
+    $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array_merge($metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')], array('NameIDFormat' => getenv('SIMPLESAMLPHP_SP_NAME_ID_FORMAT')));
+}
+
+if (null != getenv('SIMPLESAMLPHP_SP_NAME_ID_ATTRIBUTE')) {
+    $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array_merge($metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')], array('simplesaml.nameidattribute' => getenv('SIMPLESAMLPHP_SP_NAME_ID_ATTRIBUTE')));
+}


### PR DESCRIPTION
The default IDP provides transient nameids in the SAML assertions for a the user. This PR enables the option of setting new environment variables (SIMPLESAMLPHP_SP_NAME_ID_FORMAT and SIMPLESAMLPHP_SP_NAME_ID_FORMAT) which can be set to change the nameid format if needed.

For example, if I run the docker container with following environment variables:

docker run --name=testsamlidp_idp -p 8080:8080 -p 8443:8443 -e SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=<ACS> -e SIMPLESAMLPHP_SP_ENTITY_ID=<SP_ID> -e SIMPLESAMLPHP_SP_NAME_ID_FORMAT=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress -e SIMPLESAMLPHP_SP_NAME_ID_ATTRIBUTE=email -d test-saml-idp:1.0

The assertion received from the IDP will include the email address of the user as the nameId which could be useful in some cases.