### PR TITLE
Fix authsources mount path in docker compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
     - "8080:8080"
     - "8443:8443"
     #volumes:
-    #- /users.php:/var/www/simplesamlphp/config/simplesamlphp/authsources.php
+    #- ./users.php:/var/www/simplesamlphp/config/authsources.php


### PR DESCRIPTION
Tiny fix to save time for someone to figure out why mounted authsources are not working.