### PR TITLE
Update container and SimpleSamlPhp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:8.2-apache
 MAINTAINER Kristoph Junge <kristoph.junge@gmail.com>
 
 # Utilities
@@ -7,17 +7,18 @@ RUN apt-get update && \
     rm -r /var/lib/apt/lists/*
 
 # SimpleSAMLphp
-ARG SIMPLESAMLPHP_VERSION=1.15.2
-RUN curl -s -L -o /tmp/simplesamlphp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SIMPLESAMLPHP_VERSION/simplesamlphp-$SIMPLESAMLPHP_VERSION.tar.gz && \
+ARG SIMPLESAMLPHP_VERSION=2.4.4
+RUN curl -s -L -o /tmp/simplesamlphp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SIMPLESAMLPHP_VERSION/simplesamlphp-$SIMPLESAMLPHP_VERSION-full.tar.gz && \
     tar xzf /tmp/simplesamlphp.tar.gz -C /tmp && \
     rm -f /tmp/simplesamlphp.tar.gz  && \
-    mv /tmp/simplesamlphp-* /var/www/simplesamlphp && \
-    touch /var/www/simplesamlphp/modules/exampleauth/enable
-COPY config/simplesamlphp/config.php /var/www/simplesamlphp/config
-COPY config/simplesamlphp/authsources.php /var/www/simplesamlphp/config
-COPY config/simplesamlphp/saml20-sp-remote.php /var/www/simplesamlphp/metadata
-COPY config/simplesamlphp/server.crt /var/www/simplesamlphp/cert/
-COPY config/simplesamlphp/server.pem /var/www/simplesamlphp/cert/
+    mv /tmp/simplesamlphp-* /var/simplesamlphp && \
+    touch /var/simplesamlphp/modules/exampleauth/enable
+COPY config/simplesamlphp/config.php /var/simplesamlphp/config
+COPY config/simplesamlphp/authsources.php /var/simplesamlphp/config
+COPY config/simplesamlphp/saml20-sp-remote.php /var/simplesamlphp/metadata
+COPY config/simplesamlphp/saml20-idp-hosted.php /var/simplesamlphp/metadata
+COPY config/simplesamlphp/server.crt /var/simplesamlphp/cert/
+COPY config/simplesamlphp/server.pem /var/simplesamlphp/cert/
 
 # Apache
 COPY config/apache/ports.conf /etc/apache2
@@ -31,6 +32,8 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
 
 # Set work dir
 WORKDIR /var/www/simplesamlphp
+
+RUN chmod 777 /var/simplesamlphp
 
 # General setup
 EXPOSE 8080 8443

--- a/config/apache/simplesamlphp.conf
+++ b/config/apache/simplesamlphp.conf
@@ -1,23 +1,13 @@
 <VirtualHost *:8080>
     ServerName localhost
-    DocumentRoot /var/www/simplesamlphp
-    Alias /simplesaml /var/www/simplesamlphp/www
-    <Directory /var/www/simplesamlphp/www>
-        <IfModule !mod_authz_core.c>
+    DocumentRoot /var/www/service.example.com
+
+    SetEnv SIMPLESAMLPHP_CONFIG_DIR /var/simplesamlphp/config
+
+    Alias /simplesaml /var/simplesamlphp/public
+
+    <Directory /var/simplesamlphp/public>
         Require all granted
-        </IfModule>
     </Directory>
 </VirtualHost>
-<VirtualHost *:8443>
-    ServerName localhost
-    DocumentRoot /var/www/simplesamlphp
-    SSLEngine on
-    SSLCertificateFile /etc/ssl/cert/cert.crt
-    SSLCertificateKeyFile /etc/ssl/private/private.key
-    Alias /simplesaml /var/www/simplesamlphp/www
-    <Directory /var/www/simplesamlphp/www>
-        <IfModule !mod_authz_core.c>
-        Require all granted
-        </IfModule>
-    </Directory>
-</VirtualHost>
+

--- a/config/apache/simplesamlphp.conf
+++ b/config/apache/simplesamlphp.conf
@@ -10,4 +10,18 @@
         Require all granted
     </Directory>
 </VirtualHost>
+<VirtualHost *:8443>
+    ServerName localhost
+    DocumentRoot /var/www/service.example.com
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/cert/cert.crt
+    SSLCertificateKeyFile /etc/ssl/private/private.key
 
+    SetEnv SIMPLESAMLPHP_CONFIG_DIR /var/simplesamlphp/config
+
+    Alias /simplesaml /var/simplesamlphp/public
+    
+    <Directory /var/simplesamlphp/public>
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/config/simplesamlphp/config.php
+++ b/config/simplesamlphp/config.php
@@ -271,7 +271,10 @@ $config = array(
      * ),
      *
      */
-
+    
+    'module.enable' => array(
+        'exampleauth' => TRUE
+    ),
 
     /*
      * This value is the duration of the session in seconds. Make sure that the time duration of
@@ -513,11 +516,6 @@ $config = array(
         /* Add a realm attribute from edupersonprincipalname
         40 => 'core:AttributeRealm',
          */
-        45 => array(
-            'class'         => 'core:StatisticsWithAttribute',
-            'attributename' => 'realm',
-            'type'          => 'saml20-idp-SSO',
-        ),
 
         /* When called without parameters, it will fallback to filter attributes ‹the old way›
          * by checking the 'attributes' parameter in metadata on IdP hosted and SP remote.

--- a/config/simplesamlphp/config.php
+++ b/config/simplesamlphp/config.php
@@ -23,7 +23,7 @@ $config = array(
      */
     'baseurlpath' => 'simplesaml/',
     'certdir' => 'cert/',
-    'loggingdir' => 'log/',
+    'loggingdir' => '/var/simplesamlphp/log/',
     'datadir' => 'data/',
 
     /*
@@ -32,18 +32,6 @@ $config = array(
      * SimpleSAMLphp will attempt to create this directory if it doesn't exist.
      */
     'tempdir' => '/tmp/simplesaml',
-
-
-    /*
-     * If you enable this option, SimpleSAMLphp will log all sent and received messages
-     * to the log file.
-     *
-     * This option also enables logging of the messages that are encrypted and decrypted.
-     *
-     * Note: The messages are logged with the DEBUG log level, so you also need to set
-     * the 'logging.level' option to LOG_DEBUG.
-     */
-    'debug' => true,
 
     /*
      * When showerrors is enabled, all error messages and stack traces will be output
@@ -121,7 +109,7 @@ $config = array(
      * Options: [syslog,file,errorlog]
      *
      */
-    'logging.level' => SimpleSAML_Logger::DEBUG,
+    'logging.level' => SimpleSAML\Logger::DEBUG,
     'logging.handler' => 'errorlog',
 
     /*

--- a/config/simplesamlphp/saml20-idp-hosted.php
+++ b/config/simplesamlphp/saml20-idp-hosted.php
@@ -1,0 +1,19 @@
+<?php
+
+$metadata['https://example.org/saml-idp'] = [
+    /*
+     * We use '__DEFAULT__' as the hostname so we won't have to
+     * enter a hostname.
+     */
+    'host' => '__DEFAULT__',
+
+    /* The private key and certificate used by this IdP. */
+    'certificate' => 'server.crt',
+    'privatekey' => 'server.pem',
+
+    /*
+     * The authentication source for this IdP. Must be one
+     * from config/authsources.php.
+     */
+    'auth' => 'example-userpass',
+];

--- a/config/simplesamlphp/saml20-sp-remote.php
+++ b/config/simplesamlphp/saml20-sp-remote.php
@@ -6,6 +6,18 @@
  */
 
 $metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array(
-    'AssertionConsumerService' => getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE'),
-    'SingleLogoutService' => getenv('SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE'),
+    'AssertionConsumerService' => [
+        [
+            'index' => 1,
+            'isDefault' => true,
+            'Location' => getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE'),
+            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        ],
+    ],
+    'SingleLogoutService' => [
+        [
+            'Location' => getenv('SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE'),
+            'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+        ],
+    ],
 );

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026-02-09 v2.4.4
+* Update php container to version 8.2
+* Update SimpleSamlPhp to version 2.4.4
+
 ## 2018-02-04 v1.15.2-1
 
 * Changed PHP version to 7.1 instead of 7.x because of compatibility issues.

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 * Kristoph Junge
 * Huub de Beer
 * neerolyte
+* JohnnyDoesStuff


### PR DESCRIPTION
- Update php container to version 8.2
- Update SimpleSamlPhp to version 2.4.4
- Adjust path to expected default /var/simplesamlphp/
- Change directory permissions so that SimpleSamlPhp can create all files
- Reduce Apache config to bare minimum for first steps
- Migrate config
- Add newly required file saml20-idp-hosted.php
- Update saml20-sp-remote to be able to login